### PR TITLE
Remove the month from the publishing time of the source code of the paper

### DIFF
--- a/Paper/document/root.bib
+++ b/Paper/document/root.bib
@@ -2,7 +2,6 @@
     author       = {Jeltsch, Wolfgang},
     title        = {A Process Calculus for Formally Verifying Blockchain
                     Consensus Protocols},
-    month        = aug,
     year         = 2019,
     note         = {source code of the paper},
     url          = {https://github.com/jeltsch/wflp-2019}


### PR DESCRIPTION
This resolves #47.