### PR TITLE
Fix comment about `\<^noindent>` after lists

### DIFF
--- a/Paper/document/root.tex
+++ b/Paper/document/root.tex
@@ -40,7 +40,7 @@
 %    above lists. Setting \partopsep to zero prevents this extra space from being added.
 %
 %  * That said, that automatic adding of paragraph breaks causes text after a list to be considered
-%    forming a new paragraph. If this is not desired, \noindent should be used to prevent the
+%    forming a new paragraph. If this is not desired, \<^noindent> should be used to prevent the
 %    indentation that would signal the start of a new paragraph.
 
 \urlstyle{rm}


### PR DESCRIPTION
This resolves #94.